### PR TITLE
refactor: 필터 api 요청 방식 수정 및 학생 상/벌점 내역 요청 방식 수정

### DIFF
--- a/src/apis/points/index.ts
+++ b/src/apis/points/index.ts
@@ -21,10 +21,16 @@ export enum PointEnum {
 }
 
 /** 학생 상/벌점 내역 조회 */
-export const getStudentPointHistory = async (student_id: string) => {
+export const getStudentPointHistory = async (
+  student_id: string,
+  page?: number,
+  size?: number,
+) => {
   if (student_id !== '') {
     const { data } = await instance.get<Promise<StudentPointHistoryResponse>>(
-      `${router}/history/students/${student_id}`,
+      `${router}/history/students/${student_id}${
+        page || size ? `?page=${page}&size=${size}` : ''
+      }`,
     );
     return data;
   }

--- a/src/components/MultiRangeSlider.tsx
+++ b/src/components/MultiRangeSlider.tsx
@@ -23,7 +23,7 @@ export function MultiRangeSlider({
 }: PropsType) {
   const gap = 1;
   const markings = [
-    '-100+',
+    '-(100+)',
     '-80',
     '-60',
     '-40',

--- a/src/components/main/DetailBox/StudentDetailPoint.tsx
+++ b/src/components/main/DetailBox/StudentDetailPoint.tsx
@@ -9,7 +9,7 @@ interface PropsType {
 }
 
 export function StudentDetailPointList({ id }: PropsType) {
-  const { data: studentPointHistory } = useStudentPointHistory(id);
+  const { data: studentPointHistory } = useStudentPointHistory(id, 0, 4);
   const { data: studentDetail } = useStudentDetail(id);
 
   return (
@@ -23,7 +23,7 @@ export function StudentDetailPointList({ id }: PropsType) {
         </Text>
       </_StudentNameNumber>
       <_PointItemList>
-        {studentPointHistory?.point_histories.slice(0, 4).map((history) => {
+        {studentPointHistory?.point_histories.map((history) => {
           const { name, point_history_id, score, type } = history;
           return (
             <PointItem

--- a/src/hooks/usePointsApi.tsx
+++ b/src/hooks/usePointsApi.tsx
@@ -17,10 +17,14 @@ export const useAllPointHistory = (pointType: PointType) =>
     },
   );
 
-export const useStudentPointHistory = (student_id: string) =>
+export const useStudentPointHistory = (
+  student_id: string,
+  page?: number,
+  size?: number,
+) =>
   useQuery(
-    ['getStudentPointHistory', student_id],
-    () => getStudentPointHistory(student_id),
+    [`getStudentPointHistory${student_id}`, student_id, page, size],
+    () => getStudentPointHistory(student_id, page, size),
     {
       refetchOnWindowFocus: true,
     },


### PR DESCRIPTION
## 특이사항

- <!-- 변경 사항 작성 -->
- 필터 미지정시 기본값이 min: -100, max: 100으로 api 요청이 감
- 학생 상/벌점 내역 4개만 필요한 경우 현재 코드에서는 전체를 불러 4개를 짜르는 방식이지만 요청을 보낼 때 size에 4를 넣어서 보내야 함

## 관련 이슈

- resolved #109 <!-- 이슈번호 -->
